### PR TITLE
Change reject! to reject to fix create user issue

### DIFF
--- a/hipchat-api.gemspec
+++ b/hipchat-api.gemspec
@@ -20,11 +20,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('httparty')
-  
+
   s.add_development_dependency('fakeweb')
-  s.add_development_dependency('mocha')
+  s.add_development_dependency('mocha', '~> 0.11.4')
   s.add_development_dependency('rspec', '~> 2.7.0')
   s.add_development_dependency('rake')
 end
-
-

--- a/lib/hipchat-api.rb
+++ b/lib/hipchat-api.rb
@@ -134,7 +134,7 @@ module HipChat
     # @see https://www.hipchat.com/docs/api/method/users/create
     def users_create(email, name, title, is_group_admin = 0, password = nil, timezone = 'UTC')
       self.class.post(hipchat_api_url_for('users/create'), :body => {:auth_token => @token, :email => email, :name => name, :title => title,
-        :is_group_admin => is_group_admin, :password => password, :timezone => timezone}.reject!{|key, value| value.nil?})
+        :is_group_admin => is_group_admin, :password => password, :timezone => timezone}.reject{|key, value| value.nil?})
     end
 
     # Delete a user.
@@ -174,7 +174,7 @@ module HipChat
     # @see https://www.hipchat.com/docs/api/method/users/update
     def users_update(user_id, email = nil, name = nil, title = nil, is_group_admin = nil, password = nil, timezone = nil)
       self.class.post(hipchat_api_url_for('users/update'), :body => {:auth_token => @token, :user_id => user_id, :email => email,
-        :name => name, :title => title, :is_group_admin => is_group_admin, :password => password, :timezone => timezone}.reject!{|key, value| value.nil?})
+        :name => name, :title => title, :is_group_admin => is_group_admin, :password => password, :timezone => timezone}.reject{|key, value| value.nil?})
     end
 
     private

--- a/lib/hipchat-api.rb
+++ b/lib/hipchat-api.rb
@@ -4,10 +4,10 @@ require 'hipchat-api/version'
 module HipChat
   class API
     include HTTParty
-    
+
     # Default timeout of 3 seconds
     DEFAULT_TIMEOUT = 3
-    
+
     # Default headers for HTTP requests
     DEFAULT_HEADERS = {
       'User-Agent' => "HipChat gem #{VERSION}",
@@ -25,7 +25,7 @@ module HipChat
 
     # HipChat access token
     attr_accessor :token
-    
+
     # Create a new instance of the +HipChat::API+ for interacting with HipChat
     #
     # @param token [String] HipChat access token
@@ -34,16 +34,16 @@ module HipChat
       @token = token
       @hipchat_api_url = hipchat_api_url
     end
-    
+
     # Turn on HTTParty debugging
-    # 
+    #
     # @param location [Object] Output "sink" for HTTP debugging
     def debug(location = $stderr)
       self.class.debug_output(location)
     end
 
     # Set new HTTP headers for requests
-    # 
+    #
     # @param http_headers [Hash] HTTP headers
     def set_http_headers(http_headers = {})
       http_headers.merge!(DEFAULT_HEADERS)
@@ -56,31 +56,31 @@ module HipChat
     def set_timeout(timeout)
       self.class.default_timeout(timeout)
     end
-    
+
     # Creates a new room.
-    # 
+    #
     # @param name [String] Name of the room.
     # @param owner_user_id [int] User ID of the room's owner.
     # @param privacy [String, 'public'] Privacy setting for room.
     # @param topic [String, ''] Room topic.
     # @param guest_access [int, 0] Whether or not to enable guest access for this room. 0 = false, 1 = true. (default: 0).
     #
-    # @see https://www.hipchat.com/docs/api/method/rooms/create  
+    # @see https://www.hipchat.com/docs/api/method/rooms/create
     def rooms_create(name, owner_user_id, privacy = 'public', topic = '', guest_access = 0)
-      self.class.post(hipchat_api_url_for('rooms/create'), :body => {:auth_token => @token, :name => name, :owner_user_id => owner_user_id, 
+      self.class.post(hipchat_api_url_for('rooms/create'), :body => {:auth_token => @token, :name => name, :owner_user_id => owner_user_id,
         :topic => topic, :privacy => privacy, :guest_access => guest_access})
     end
-    
-    # Deletes a room and kicks the current participants. 
-    # 
+
+    # Deletes a room and kicks the current participants.
+    #
     # @param room_id [int] ID of the room
     #
     # @see https://www.hipchat.com/docs/api/method/rooms/delete
     def rooms_delete(room_id)
-      self.class.post(hipchat_api_url_for('rooms/delete'), :body => {:auth_token => @token, :room_id => room_id})      
+      self.class.post(hipchat_api_url_for('rooms/delete'), :body => {:auth_token => @token, :room_id => room_id})
     end
 
-    # Fetch chat history for this room. 
+    # Fetch chat history for this room.
     #
     # @param room_id [int] ID of the room.
     # @param date [String] Either the date to fetch history for in YYYY-MM-DD format, or "recent" to fetch the latest 50 messages.
@@ -88,74 +88,74 @@ module HipChat
     #
     # @see https://www.hipchat.com/docs/api/method/rooms/history
     def rooms_history(room_id, date, timezone)
-      self.class.get(hipchat_api_url_for('rooms/history'), :query => {:auth_token => @token, :room_id => room_id, :date => date, 
+      self.class.get(hipchat_api_url_for('rooms/history'), :query => {:auth_token => @token, :room_id => room_id, :date => date,
         :timezone => timezone})
     end
 
-    # List rooms for this group. 
-    #   
+    # List rooms for this group.
+    #
     # @see https://www.hipchat.com/docs/api/method/rooms/list
     def rooms_list
       self.class.get(hipchat_api_url_for('rooms/list'), :query => {:auth_token => @token})
     end
-    
+
     # Send a message to a room.
-    # 
+    #
     # @param room_id [int] ID of the room.
     # @param from [String] Name the message will appear be sent from. Must be less than 15 characters long. May contain letters, numbers, -, _, and spaces.
-    # @param message [String] The message body. Must be valid XHTML. HTML entities must be escaped (e.g.: &amp; instead of &). May contain basic tags: a, b, i, strong, em, br, img, pre, code. 5000 characters max. 
+    # @param message [String] The message body. Must be valid XHTML. HTML entities must be escaped (e.g.: &amp; instead of &). May contain basic tags: a, b, i, strong, em, br, img, pre, code. 5000 characters max.
     # @param notify [int] Boolean flag of whether or not this message should trigger a notification for people in the room (based on their individual notification preferences). 0 = false, 1 = true. (default: 0)
-    # @param color [String] Background color for message. One of "yellow", "red", "green", "purple", or "random". (default: yellow) 
+    # @param color [String] Background color for message. One of "yellow", "red", "green", "purple", or "random". (default: yellow)
     # @param message_format [String] Determines how the message is treated by HipChat's server and rendered inside HipChat applications. One of "html" or "text". (default: html)
     # @see https://www.hipchat.com/docs/api/method/rooms/message
     def rooms_message(room_id, from, message, notify = 0, color = 'yellow', message_format = 'html')
-      self.class.post(hipchat_api_url_for('rooms/message'), :body => {:auth_token => @token, :room_id => room_id, :from => from, 
+      self.class.post(hipchat_api_url_for('rooms/message'), :body => {:auth_token => @token, :room_id => room_id, :from => from,
         :message => message, :notify => notify, :color => color, :message_format => message_format})
     end
 
     # Get room details.
-    # 
+    #
     # @param room_id [int] ID of the room.
     #
     # @see https://www.hipchat.com/docs/api/method/rooms/show
     def rooms_show(room_id)
       self.class.get(hipchat_api_url_for('rooms/show'), :query => {:auth_token => @token, :room_id => room_id})
     end
-        
+
     # Create a new user in your group.
-    # 
+    #
     # @param email [String] User's email.
-    # @param name [String] User's full name. 
-    # @param title [String] User's title. 
-    # @param is_group_admin [int] Whether or not this user is an admin. 0 = false, 1 = true. (default: 0) 
-    # @param password [String, nil] User's password. If not provided, a randomly generated password will be returned. 
-    # @param timezone [String, 'UTC'] User's timezone. Must be a PHP supported timezone. (default: UTC) 
+    # @param name [String] User's full name.
+    # @param title [String] User's title.
+    # @param is_group_admin [int] Whether or not this user is an admin. 0 = false, 1 = true. (default: 0)
+    # @param password [String, nil] User's password. If not provided, a randomly generated password will be returned.
+    # @param timezone [String, 'UTC'] User's timezone. Must be a PHP supported timezone. (default: UTC)
     #
     # @see https://www.hipchat.com/docs/api/method/users/create
     def users_create(email, name, title, is_group_admin = 0, password = nil, timezone = 'UTC')
-      self.class.post(hipchat_api_url_for('users/create'), :body => {:auth_token => @token, :email => email, :name => name, :title => title, 
+      self.class.post(hipchat_api_url_for('users/create'), :body => {:auth_token => @token, :email => email, :name => name, :title => title,
         :is_group_admin => is_group_admin, :password => password, :timezone => timezone}.reject!{|key, value| value.nil?})
     end
 
-    # Delete a user. 
-    # 
-    # @param user_id [String] ID or email address of the user. 
+    # Delete a user.
+    #
+    # @param user_id [String] ID or email address of the user.
     #
     # @see https://www.hipchat.com/docs/api/method/users/delete
     def users_delete(user_id)
       self.class.post(hipchat_api_url_for('users/delete'), :body => {:auth_token => @token, :user_id => user_id})
     end
 
-    # List all users in the group. 
+    # List all users in the group.
     #
     # @see https://www.hipchat.com/docs/api/method/users/list
     def users_list
       self.class.get(hipchat_api_url_for('users/list'), :query => {:auth_token => @token})
     end
 
-    # Get a user's details. 
-    # 
-    # @param user_id [String] ID or email address of the user. 
+    # Get a user's details.
+    #
+    # @param user_id [String] ID or email address of the user.
     #
     # @see https://www.hipchat.com/docs/api/method/users/show
     def users_show(user_id)
@@ -163,22 +163,22 @@ module HipChat
     end
 
     # Update a user.
-    # 
+    #
     # @param email [String] User's email.
-    # @param name [String] User's full name. 
-    # @param title [String] User's title. 
-    # @param is_group_admin [int] Whether or not this user is an admin. 0 = false, 1 = true. (default: 0) 
+    # @param name [String] User's full name.
+    # @param title [String] User's title.
+    # @param is_group_admin [int] Whether or not this user is an admin. 0 = false, 1 = true. (default: 0)
     # @param password [String, nil] User's password.
-    # @param timezone [String, nil] User's timezone. Must be a PHP supported timezone. (default: UTC) 
+    # @param timezone [String, nil] User's timezone. Must be a PHP supported timezone. (default: UTC)
     #
     # @see https://www.hipchat.com/docs/api/method/users/update
     def users_update(user_id, email = nil, name = nil, title = nil, is_group_admin = nil, password = nil, timezone = nil)
-      self.class.post(hipchat_api_url_for('users/update'), :body => {:auth_token => @token, :user_id => user_id, :email => email, 
+      self.class.post(hipchat_api_url_for('users/update'), :body => {:auth_token => @token, :user_id => user_id, :email => email,
         :name => name, :title => title, :is_group_admin => is_group_admin, :password => password, :timezone => timezone}.reject!{|key, value| value.nil?})
     end
-    
+
     private
-    
+
     # Create a URL appropriate for accessing the HipChat API with a given API method.
     #
     # @param method [String] HipChat API method

--- a/spec/hipchat-api_spec.rb
+++ b/spec/hipchat-api_spec.rb
@@ -107,9 +107,13 @@ describe "HipChat::API" do
                          :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_create_response.json'),
                          :content_type => "application/json")
 
-    users_create_response = @hipchat_api.users_create('new@company.com', 'New Guy', 'intern')
+    users_create_response = @hipchat_api.users_create('new@company.com', 'New Guy', 'intern', is_group_admin = 0, 'changeme')
     users_create_response.should_not be nil
     users_create_response['user']['name'].should == 'New Guy'
+
+    # Make sure the new user's password was sent
+    FakeWeb.last_request.body.should_not be_nil
+    FakeWeb.last_request.body.should match 'changeme'
   end
 
   it "should delete a user" do

--- a/spec/hipchat-api_spec.rb
+++ b/spec/hipchat-api_spec.rb
@@ -12,34 +12,34 @@ describe "HipChat::API" do
   after(:each) do
     FakeWeb.allow_net_connect = true
   end
-    
+
   it "should be the correct version" do
     HipChat::API::VERSION.should == '1.0.3'
   end
-  
-  it "should create a new instance with the correct parameters" do  
+
+  it "should create a new instance with the correct parameters" do
     @hipchat_api.token.should be == 'token'
     @hipchat_api.hipchat_api_url.should == HipChat::API::HIPCHAT_API_URL
   end
-  
+
   it "should allow http headers to be set" do
     @hipchat_api.expects(:headers).at_least_once
-    
+
     @hipchat_api.set_http_headers({'Accept' => 'application/json'})
   end
-  
+
   it "should allow a timeout to be set" do
     @hipchat_api.expects(:default_timeout).at_least_once
-    
+
     @hipchat_api.set_timeout(10)
   end
-  
+
   it "should allow you to create a room" do
-    FakeWeb.register_uri(:post, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/create|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_create_response.json'), 
+    FakeWeb.register_uri(:post,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/create|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_create_response.json'),
                          :content_type => "application/json")
-  
+
     rooms_create_response = @hipchat_api.rooms_create('Development', 5)
     rooms_create_response.should_not be nil
     rooms_create_response['room']['name'].should == 'Development'
@@ -47,110 +47,110 @@ describe "HipChat::API" do
   end
 
   it "should allow you to delete a room" do
-    FakeWeb.register_uri(:post, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/delete|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_delete_response.json'), 
+    FakeWeb.register_uri(:post,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/delete|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_delete_response.json'),
                          :content_type => "application/json")
-  
+
     rooms_delete_response = @hipchat_api.rooms_delete(5)
     rooms_delete_response.should_not be nil
     rooms_delete_response['deleted'].should be true
   end
-  
+
   it "should return a list of rooms" do
-    FakeWeb.register_uri(:get, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/list|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_list_response.json'), 
+    FakeWeb.register_uri(:get,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/list|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_list_response.json'),
                          :content_type => "application/json")
-  
+
     rooms_list_response = @hipchat_api.rooms_list
     rooms_list_response.should_not be nil
     rooms_list_response['rooms'].size.should be 2
   end
-  
+
   it "should return the correct room informaton for a room_id" do
-    FakeWeb.register_uri(:get, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/show|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_show_response.json'), 
+    FakeWeb.register_uri(:get,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/show|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_show_response.json'),
                          :content_type => "application/json")
-  
+
     rooms_show_response = @hipchat_api.rooms_show(7)
     rooms_show_response.should_not be nil
     rooms_show_response['room']['topic'].should == 'Chef is so awesome.'
   end
 
   it "should send a message" do
-    FakeWeb.register_uri(:post, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/message|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_message_response.json'), 
+    FakeWeb.register_uri(:post,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/message|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_message_response.json'),
                          :content_type => "application/json")
-  
+
     rooms_message_response = @hipchat_api.rooms_message(10, 'Alerts', 'A new user signed up')
     rooms_message_response.should_not be nil
     rooms_message_response['status'].should == 'sent'
   end
 
   it "should return a history of messages" do
-    FakeWeb.register_uri(:get, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/history|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_history_response.json'), 
+    FakeWeb.register_uri(:get,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/rooms/history|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'rooms_history_response.json'),
                          :content_type => "application/json")
-  
+
     rooms_history_response = @hipchat_api.rooms_history(10, '2010-11-19', 'PST')
     rooms_history_response.should_not be nil
     rooms_history_response['messages'].size.should be 3
   end
 
   it "should create a user" do
-    FakeWeb.register_uri(:post, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/create|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_create_response.json'), 
+    FakeWeb.register_uri(:post,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/create|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_create_response.json'),
                          :content_type => "application/json")
-  
+
     users_create_response = @hipchat_api.users_create('new@company.com', 'New Guy', 'intern')
     users_create_response.should_not be nil
     users_create_response['user']['name'].should == 'New Guy'
   end
 
   it "should delete a user" do
-    FakeWeb.register_uri(:post, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/delete|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_delete_response.json'), 
+    FakeWeb.register_uri(:post,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/delete|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_delete_response.json'),
                          :content_type => "application/json")
-  
+
     users_delete_response = @hipchat_api.users_delete(5)
     users_delete_response.should_not be nil
     users_delete_response['deleted'].should be true
   end
 
   it "should return a list of users" do
-    FakeWeb.register_uri(:get, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/list|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_list_response.json'), 
+    FakeWeb.register_uri(:get,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/list|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_list_response.json'),
                          :content_type => "application/json")
-  
+
     users_list_response = @hipchat_api.users_list
     users_list_response.should_not be nil
     users_list_response['users'].size.should be 3
   end
 
   it "should show the details for a user" do
-    FakeWeb.register_uri(:get, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/show|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_show_response.json'), 
+    FakeWeb.register_uri(:get,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/show|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_show_response.json'),
                          :content_type => "application/json")
-  
+
     users_show_response = @hipchat_api.users_show(5)
     users_show_response.should_not be nil
     users_show_response['user']['name'].should == 'Garret Heaton'
   end
-  
+
   it "should update a user" do
-    FakeWeb.register_uri(:post, 
-                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/update|, 
-                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_update_response.json'), 
+    FakeWeb.register_uri(:post,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/update|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_update_response.json'),
                          :content_type => "application/json")
-  
+
     users_update_response = @hipchat_api.users_update(5, 'new-email-address@hipchat.com')
     users_update_response.should_not be nil
     users_update_response['user']['email'].should == 'new-email-address@hipchat.com'


### PR DESCRIPTION
If you set a password in users_create, the reject! call doesn't reject any parameters and therefore returns nil. Instead, use reject which returns just the retained parameters. Also added a spec for this and updated a dependency to fix a mocha issue on clean checkout.
