### PR TITLE
Added optional parameter to include deleted users in users_list

### DIFF
--- a/lib/hipchat-api.rb
+++ b/lib/hipchat-api.rb
@@ -159,9 +159,13 @@ module HipChat
 
     # List all users in the group.
     #
+    # @param notify [bool] Boolean flag of whether or not include deleted users 0 = false, 1 = true. (default: 0)
+    #
     # @see https://www.hipchat.com/docs/api/method/users/list
-    def users_list
-      self.class.get(hipchat_api_url_for('users/list'), :query => {:auth_token => @token})
+    def users_list(include_deleted = 0)
+      query = {:auth_token => @token}
+      query[:include_deleted] = 1 if include_deleted == 1
+      self.class.get(hipchat_api_url_for('users/list'), :query => query)
     end
 
     # Get a user's details.

--- a/spec/fakeweb/users_list_include_deleted_response.json
+++ b/spec/fakeweb/users_list_include_deleted_response.json
@@ -1,0 +1,29 @@
+{ "users" : [ { "email" : "chris@hipchat.com",
+        "is_group_admin" : 1,
+        "name" : "Chris Rivers",
+        "photo_url" : "https://www.hipchat.com/chris.png",
+        "status" : "away",
+        "status_message" : "gym, bbl",
+        "title" : "Developer",
+        "user_id" : 1
+      },
+      { "email" : "pete@hipchat.com",
+        "is_group_admin" : 1,
+        "name" : "Peter Curley",
+        "photo_url" : "https://www.hipchat.com/pete.png",
+        "status" : "offline",
+        "status_message" : "",
+        "title" : "Designer",
+        "user_id" : 3
+      },
+      { "email" : "garret@hipchat.com",
+        "is_group_admin" : 1,
+        "name" : "Garret Heaton",
+        "photo_url" : "https://www.hipchat.com/garret.png",
+        "status" : "available",
+        "status_message" : "Come see what I'm working on!",
+        "title" : "Co-founder",
+        "user_id" : 5,
+	"is_deleted" : 1
+      }
+    ] }

--- a/spec/hipchat-api_spec.rb
+++ b/spec/hipchat-api_spec.rb
@@ -149,6 +149,19 @@ describe "HipChat::API" do
     users_list_response['users'].size.should be 3
   end
 
+  it "should return a list of users including deleted" do
+    FakeWeb.register_uri(:get,
+                         %r|#{HipChat::API::HIPCHAT_API_URL}/users/list.*include_deleted=1|,
+                         :body => File.join(File.dirname(__FILE__), 'fakeweb', 'users_list_include_deleted_response.json'),
+                         :content_type => "application/json")
+
+    users_list_response = @hipchat_api.users_list(include_deleted = 1)
+    users_list_response.should_not be nil
+    users_list_response['users'].size.should be 3
+    users_list_response['users'].select { |u| u['is_deleted'] == 1 }.size.should be 1
+    users_list_response['users'].select { |u| u['is_deleted'] != 1 }.size.should be 2
+  end
+
   it "should show the details for a user" do
     FakeWeb.register_uri(:get,
                          %r|#{HipChat::API::HIPCHAT_API_URL}/users/show|,


### PR DESCRIPTION
Added the optional parameter to include deleted users in users_list, as =1 or =0, default 0 (no include). I did not bump the version.
